### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/813/11/85681311.geojson
+++ b/data/856/813/11/85681311.geojson
@@ -406,6 +406,9 @@
         "wd:id":"Q31057"
     },
     "wof:country":"NF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"50aca10057ee2b0f41417af3a5dfc147",
     "wof:hierarchy":[
         {
@@ -423,7 +426,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1561766411,
+    "wof:lastmodified":1582355576,
     "wof:name":"Norfolk Island",
     "wof:parent_id":85632517,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.