### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/890/440/179/890440179.geojson
+++ b/data/890/440/179/890440179.geojson
@@ -28,6 +28,9 @@
     "name:arg_x_preferred":[
         "Kingston"
     ],
+    "name:arz_x_preferred":[
+        "\u06a9\u06cc\u0646\u06af\u0633\u062a\u0648\u0646"
+    ],
     "name:ast_x_preferred":[
         "Kingston"
     ],
@@ -36,6 +39,9 @@
     ],
     "name:bel_x_preferred":[
         "\u041f\u0430\u0441\u0451\u043b\u0430\u043a \u041a\u0456\u043d\u0433\u0441\u0442\u0430\u043d"
+    ],
+    "name:bel_x_variant":[
+        "\u041a\u0456\u043d\u0433\u0441\u0442\u0430\u043d"
     ],
     "name:ben_x_preferred":[
         "\u0995\u09bf\u0982\u09b8\u099f\u09a8"
@@ -217,6 +223,9 @@
     "name:tam_x_preferred":[
         "\u0b95\u0bbf\u0b99\u0bcd\u0b9a\u0bc1\u0b9f\u0ba9\u0bcd"
     ],
+    "name:tgk_x_preferred":[
+        "\u041a\u0438\u043d\u0433\u0441\u0442\u043e\u043d"
+    ],
     "name:tha_x_preferred":[
         "\u0e04\u0e34\u0e07\u0e2a\u0e4c\u0e15\u0e31\u0e19"
     ],
@@ -237,6 +246,12 @@
     ],
     "name:wln_x_preferred":[
         "Kingston"
+    ],
+    "name:wuu_x_preferred":[
+        "\u91d1\u65af\u6566"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10d9\u10d8\u10dc\u10d2\u10e1\u10e2\u10dd\u10dc\u10d8"
     ],
     "name:yue_x_preferred":[
         "\u4eac\u58eb\u9813"
@@ -278,7 +293,7 @@
         }
     ],
     "wof:id":890440179,
-    "wof:lastmodified":1636502499,
+    "wof:lastmodified":1690848324,
     "wof:name":"Kingston",
     "wof:parent_id":85681311,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.